### PR TITLE
Fixed directory replacement mismatch error

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ You'll need python3 installed. That's it!
 
 ### Installation:
  
- 1. Place in your GW2 folder (likely 'C:/program files/guild wars 2/' or something)
+ 1. Place in your GW2 folder (likely 'C:/Program Files/Guild Wars 2/' or something)
  2. Run 'install.bat'.
  3. Drag 'run.bat' file to somewhere convenient (like your desktop!).
  4. Double-click 'run.bat' any time you wanna check for updates!

--- a/ac-data/runTmp.bat
+++ b/ac-data/runTmp.bat
@@ -1,4 +1,4 @@
-cd "E:\projects\samCheckArc"
+cd replaceMe
 echo You forgot to run install.bat or setup.py first!
 goto:eof
 python ac-data/arc-check.py

--- a/ac-data/setup.py
+++ b/ac-data/setup.py
@@ -13,7 +13,6 @@ if(not(os.path.exists('gw2.exe')) and not(os.path.exists('gw2-64.exe'))):
 lines = []
 with open(filename) as inFile:
     for line in inFile:
-        print("LINE:",line)
         if line.strip() == "echo You forgot to run install.bat or setup.py first!" or line.strip() == "goto:eof":
             continue
         lines.append(line.replace('replaceMe', os.getcwd()))


### PR DESCRIPTION
This was entirely my fault: the setup.py was supposed to replace `replaceMe` with the actual directory, but I forgot to... actually include that line-to-be-replaced in the code. Should work now!